### PR TITLE
Manage default value in filters

### DIFF
--- a/src/test/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEndingTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEndingTest.java
@@ -102,6 +102,8 @@ public class MultiDelimiterInterpolatorFilterReaderLineEndingTest
         reader.setDelimiterSpecs( new HashSet<String>( Arrays.asList( "${*}", "@" ) ) );
 
         assertEquals( "toto@titi.com bar", IOUtil.toString( reader ) );
+
+
     }
 
     // http://stackoverflow.com/questions/21786805/maven-war-plugin-customize-filter-delimitters-in-webresources/
@@ -120,5 +122,26 @@ public class MultiDelimiterInterpolatorFilterReaderLineEndingTest
         reader.setDelimiterSpecs( new HashSet<String>( Arrays.asList( "${*}", "@" ) ) );
 
         assertEquals( "  url=\"jdbc:oracle:thin:@DB_SERVER:DB_PORT:DB_NAME\"", IOUtil.toString( reader ) );
+    }
+    
+    @Test
+    public void testDefaultValue()
+        throws Exception
+    {
+        
+        Reader in = new StringReader( "toto@titi.com ${noValue:defaultValue}" );
+        MultiDelimiterInterpolatorFilterReaderLineEnding reader = new MultiDelimiterInterpolatorFilterReaderLineEnding( in, interpolator, true );
+        reader.setDelimiterSpecs( new HashSet<String>( Arrays.asList( "${*}", "@" ) ) );
+
+        assertEquals( "defaultValue", IOUtil.toString( reader ) );
+        
+        
+        when( interpolator.interpolate( eq( "${hasAValue}" ), eq( "" ), isA( RecursionInterceptor.class ) ) ).thenReturn( "42" );
+
+        in = new StringReader( "toto@titi.com ${hasAValue:defaultvalue}" );
+        reader = new MultiDelimiterInterpolatorFilterReaderLineEnding( in, interpolator, true );
+        reader.setDelimiterSpecs( new HashSet<String>( Arrays.asList( "${*}", "@" ) ) );
+
+        assertEquals( "toto@titi.com 42", IOUtil.toString( reader ) );
     }
 }


### PR DESCRIPTION
Not sure if this is the good place to contribute, let me know :)

The goal is to manage defaut value  like ${toto:tutu} where tutu is used when no value for toto is found.
It is the same behavior as Spring's [PropertyPlaceholderConfigurer](https://www.mkyong.com/spring/spring-propertyplaceholderconfigurer-example/)

