### PR TITLE
[MRESOURCES-250] - Add ability to flatten folder structure into target directory when copying resources

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
+++ b/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -227,6 +229,19 @@ public class DefaultMavenResourcesFiltering
 
                 File destinationFile = getDestinationFile( outputDirectory, targetPath, name, mavenResourcesExecution );
 
+                if ( mavenResourcesExecution.isFlatten() && destinationFile.exists() )
+                {
+                    if ( mavenResourcesExecution.isOverwrite() )
+                    {
+                        getLogger().warn( "existing file " + destinationFile.getName()
+                                + " will be overwritten by " + name );
+                    }
+                    else
+                    {
+                        throw new MavenFilteringException( "existing file " + destinationFile.getName()
+                                + " will be overwritten by " + name + " and overwrite was not set to true" );
+                    }
+                }
                 boolean filteredExt =
                     filteredFileExtension( source.getName(), mavenResourcesExecution.getNonFilteredFileExtensions() );
 
@@ -275,7 +290,17 @@ public class DefaultMavenResourcesFiltering
                                      MavenResourcesExecution mavenResourcesExecution )
                                          throws MavenFilteringException
     {
-        String destination = name;
+        String destination;
+        if ( !mavenResourcesExecution.isFlatten() )
+        {
+            destination = name;
+        }
+        else
+        {
+            Path path = Paths.get( name );
+            Path filePath = path.getFileName();
+            destination = filePath.toString();
+        }
 
         if ( mavenResourcesExecution.isFilterFilenames() && mavenResourcesExecution.getFilterWrappers().size() > 0 )
         {

--- a/src/main/java/org/apache/maven/shared/filtering/MavenResourcesExecution.java
+++ b/src/main/java/org/apache/maven/shared/filtering/MavenResourcesExecution.java
@@ -108,6 +108,12 @@ public class MavenResourcesExecution
     private boolean supportMultiLineFiltering;
 
     /**
+     * Write resources to a flattened directory structure.
+     *
+     */
+    private boolean flatten = false;
+
+    /**
      * Do nothing.
      */
     public MavenResourcesExecution()
@@ -355,6 +361,26 @@ public class MavenResourcesExecution
     public void setOverwrite( boolean overwrite )
     {
         this.overwrite = overwrite;
+    }
+
+    /**
+     * Write to flattened directory structure.
+     *
+     * @return {@link #flatten}
+     */
+    public boolean isFlatten()
+    {
+        return flatten;
+    }
+
+    /**
+     * Write to flattened directory structure.
+     *
+     * @param flatten flatten true or false.
+     */
+    public void setFlatten( boolean flatten )
+    {
+        this.flatten = flatten;
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
@@ -489,6 +489,88 @@ public class DefaultMavenResourcesFilteringTest
 
     }
 
+    public void testFlattenDirectoryStructure()
+            throws Exception
+    {
+        File baseDir = new File( "c:\\foo\\bar" );
+        StubMavenProject mavenProject = new StubMavenProject( baseDir );
+        mavenProject.setVersion( "1.0" );
+        mavenProject.setGroupId( "org.apache" );
+        mavenProject.setName( "test project" );
+
+        MavenResourcesFiltering mavenResourcesFiltering = lookup( MavenResourcesFiltering.class );
+
+        String unitFilesDir = getBasedir() + "/src/test/units-files/maven-resources-filtering";
+
+        Resource resource = new Resource();
+        List<Resource> resources = new ArrayList<>();
+        resources.add( resource );
+        resource.setDirectory( unitFilesDir );
+        resource.setFiltering( true );
+        resource.addInclude( "includ*" );
+        resource.addInclude( "**/includ*" );
+
+        List<String> filtersFile = new ArrayList<>();
+        filtersFile.add( getBasedir()
+                + "/src/test/units-files/maven-resources-filtering/empty-maven-resources-filtering.txt" );
+
+        MavenResourcesExecution mavenResourcesExecution =
+                new MavenResourcesExecution( resources, outputDirectory, mavenProject, "UTF-8", filtersFile,
+                        Collections.<String> emptyList(), new StubMavenSession() );
+        mavenResourcesExecution.setFlatten(true);
+        mavenResourcesExecution.setOverwrite(true);
+        mavenResourcesFiltering.filterResources( mavenResourcesExecution );
+
+        File[] files = outputDirectory.listFiles();
+        assertNotNull( files );
+        assertEquals( 2, files.length );
+        File includeFile = new File( outputDirectory, "includefile.txt" );
+        assertTrue( includeFile.exists() );
+
+        includeFile = new File( outputDirectory, "include.txt" );
+        assertTrue( includeFile.exists() );
+
+    }
+
+    public void testFlattenDirectoryStructureWithoutOverride()
+            throws Exception
+    {
+        File baseDir = new File( "c:\\foo\\bar" );
+        StubMavenProject mavenProject = new StubMavenProject( baseDir );
+        mavenProject.setVersion( "1.0" );
+        mavenProject.setGroupId( "org.apache" );
+        mavenProject.setName( "test project" );
+
+        MavenResourcesFiltering mavenResourcesFiltering = lookup( MavenResourcesFiltering.class );
+
+        String unitFilesDir = getBasedir() + "/src/test/units-files/maven-resources-filtering";
+
+        Resource resource = new Resource();
+        List<Resource> resources = new ArrayList<>();
+        resources.add( resource );
+        resource.setDirectory( unitFilesDir );
+        resource.setFiltering( true );
+        resource.addInclude( "includ*" );
+        resource.addInclude( "**/includ*" );
+
+        List<String> filtersFile = new ArrayList<>();
+        filtersFile.add( getBasedir()
+                + "/src/test/units-files/maven-resources-filtering/empty-maven-resources-filtering.txt" );
+
+        MavenResourcesExecution mavenResourcesExecution =
+                new MavenResourcesExecution( resources, outputDirectory, mavenProject, "UTF-8", filtersFile,
+                        Collections.<String> emptyList(), new StubMavenSession() );
+        mavenResourcesExecution.setFlatten(true);
+        mavenResourcesExecution.setOverwrite(false);
+        try {
+            mavenResourcesFiltering.filterResources(mavenResourcesExecution);
+        } catch (MavenFilteringException e) {
+            return;
+        }
+        fail("Copying directory structure with duplicate filename includefile.txt should have failed with overwrite");
+
+    }
+
     public void testExcludeOneFile()
         throws Exception
     {

--- a/src/test/units-files/maven-resources-filtering/includedir/includefile.txt
+++ b/src/test/units-files/maven-resources-filtering/includedir/includefile.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
This change is the preparation to enabling the maven-resources-plugin to make use of a new version of the filtering library the allows the resource plugin to copy resources to a flattened directory structure.