### PR TITLE
[MRESOURCES-258] Copying and filtering logic is delegated to FileUtils

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/DefaultMavenFileFilter.java
+++ b/src/main/java/org/apache/maven/shared/filtering/DefaultMavenFileFilter.java
@@ -19,30 +19,14 @@ package org.apache.maven.shared.filtering;
  * under the License.
  */
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
 import java.util.List;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.utils.StringUtils;
 import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.utils.io.FileUtils.FilterWrapper;
-import org.apache.maven.shared.utils.io.IOUtil;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.sonatype.plexus.build.incremental.BuildContext;
@@ -110,7 +94,8 @@ public class DefaultMavenFileFilter
                 {
                     getLogger().debug( "filtering " + from.getPath() + " to " + to.getPath() );
                 }
-                filterFile( from, to, encoding, filterWrappers );
+                FilterWrapper[] array = filterWrappers.toArray( new FilterWrapper[0] );
+                FileUtils.copyFile( from, to, encoding, array, false );
             }
             else
             {
@@ -127,62 +112,5 @@ public class DefaultMavenFileFilter
         {
             throw new MavenFilteringException( e.getMessage(), e );
         }
-
     }
-
-    private void filterFile( @Nonnull File from, @Nonnull File to, @Nullable String encoding,
-                             @Nullable List<FilterWrapper> wrappers )
-                                 throws IOException, MavenFilteringException
-    {
-        if ( wrappers != null && wrappers.size() > 0 )
-        {
-            
-            
-            try ( Reader fileReader = getFileReader( encoding, from );
-                  Writer fileWriter = getFileWriter( encoding, to ) )
-            {
-                Reader src = readerFilter.filter( fileReader, true, wrappers );
-
-                IOUtil.copy( src, fileWriter );
-            }
-        }
-        else
-        {
-            if ( to.lastModified() < from.lastModified() )
-            {
-                FileUtils.copyFile( from, to );
-            }
-        }
-    }
-
-    private Writer getFileWriter( String encoding, File to )
-        throws IOException
-    {
-        if ( StringUtils.isEmpty( encoding ) )
-        {
-            return new FileWriter( to );
-        }
-        else
-        {
-            FileOutputStream outstream = new FileOutputStream( to );
-
-            return new OutputStreamWriter( outstream, encoding );
-        }
-    }
-
-    private Reader getFileReader( String encoding, File from )
-        throws FileNotFoundException, UnsupportedEncodingException
-    {
-        // buffer so it isn't reading a byte at a time!
-        if ( StringUtils.isEmpty( encoding ) )
-        {
-            return new BufferedReader( new FileReader( from ) );
-        }
-        else
-        {
-            FileInputStream instream = new FileInputStream( from );
-            return new BufferedReader( new InputStreamReader( instream, encoding ) );
-        }
-    }
-
 }


### PR DESCRIPTION
- Removed `filterFile(..)` method in favour of using the duplicate logic in the shared `FileUtils`.
- Removed `getFileWriter(..)`as it was no longer used.
- Removed `getFileReader(..)`as it was no longer used.

This should allow us to benefit from improvements to be made in `FileUtils`.