### PR TITLE
Support JSON format for parameter filter files #MRESOURCES-284

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
     <contributor>
       <name>Graham Leggett</name>
     </contributor>
+    <contributor>
+      <url>@ImadBL</url>
+      <name>Imad BELMOUJAHID</name>
+      <email>belmoujahid.i@gmail.com</email>
+    </contributor>
   </contributors>
 
   <dependencies>
@@ -94,6 +99,11 @@
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-shared-utils</artifactId>
       <version>3.3.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/main/java/org/apache/maven/shared/filtering/AbstractMavenFilteringRequest.java
+++ b/src/main/java/org/apache/maven/shared/filtering/AbstractMavenFilteringRequest.java
@@ -28,12 +28,15 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
 /**
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
  * @since 1.0-beta-3
  */
 public class AbstractMavenFilteringRequest
 {
 
     private MavenProject mavenProject;
+
+    private String rootNode;
 
     private List<String> filters;
 
@@ -170,6 +173,24 @@ public class AbstractMavenFilteringRequest
     public void setFileFilters( List<String> paramfilters )
     {
         setFilters( paramfilters );
+    }
+
+    /**
+     * get RootNode
+     * @return String using with json file
+     */
+    public String getRootNode()
+    {
+        return rootNode;
+    }
+
+    /**
+     * set RootNode
+     * @param rootNode String using with json file
+     */
+    public void setRootNode( String rootNode )
+    {
+        this.rootNode = rootNode;
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/filtering/BaseFilter.java
+++ b/src/main/java/org/apache/maven/shared/filtering/BaseFilter.java
@@ -46,6 +46,9 @@ import org.codehaus.plexus.interpolation.ValueSource;
 import org.codehaus.plexus.interpolation.multi.MultiDelimiterStringSearchInterpolator;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 
+/**
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
+ */
 class BaseFilter
     extends AbstractLogEnabled
     implements DefaultFilterInfo
@@ -120,7 +123,7 @@ class BaseFilter
 
         File basedir = request.getMavenProject() != null ? request.getMavenProject().getBasedir() : new File( "." );
 
-        loadProperties( filterProperties, basedir, request.getFileFilters(), baseProps );
+        loadProperties( filterProperties, basedir, request.getFileFilters(), baseProps, request.getRootNode() );
         if ( filterProperties.size() < 1 )
         {
             filterProperties.putAll( baseProps );
@@ -138,7 +141,7 @@ class BaseFilter
                     buildFilters.removeAll( request.getFileFilters() );
                 }
 
-                loadProperties( filterProperties, basedir, buildFilters, baseProps );
+                loadProperties( filterProperties, basedir, buildFilters, baseProps, request.getRootNode() );
             }
 
             // Project properties
@@ -182,10 +185,11 @@ class BaseFilter
     }
 
     /**
+     * UseRootThisNode this parameter is null (used only for JSON files) for more information ### MRESOURCES-284 ###
      * default visibility only for testing reason !
      */
     void loadProperties( Properties filterProperties, File basedir, List<String> propertiesFilePaths,
-                         Properties baseProps )
+                         Properties baseProps, String rootNode )
                              throws MavenFilteringException
     {
         if ( propertiesFilePaths != null )
@@ -203,7 +207,8 @@ class BaseFilter
                 try
                 {
                     File propFile = FileUtils.resolveFile( basedir, filterFile );
-                    Properties properties = PropertyUtils.loadPropertyFile( propFile, workProperties, getLogger() );
+                    Properties properties = PropertyUtils.loadPropertyFile( propFile, workProperties, getLogger(),
+                            rootNode );
                     filterProperties.putAll( properties );
                     workProperties.putAll( properties );
                 }

--- a/src/main/java/org/apache/maven/shared/filtering/MavenResourcesExecution.java
+++ b/src/main/java/org/apache/maven/shared/filtering/MavenResourcesExecution.java
@@ -34,7 +34,7 @@ import org.codehaus.plexus.interpolation.ValueSource;
 
 /**
  * A bean to configure a resources filtering execution.
- *
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
  * @author Olivier Lamy
  */
 public class MavenResourcesExecution
@@ -119,11 +119,42 @@ public class MavenResourcesExecution
     private boolean flatten = false;
 
     /**
+     * rootNode
+     */
+    private String rootNode;
+
+    /**
      * Do nothing.
      */
     public MavenResourcesExecution()
     {
         // no op
+    }
+
+    /**
+     *
+     * @param resources The list of resources.
+     * @param outputDirectory The output directory.
+     * @param mavenProject The maven project.
+     * @param encoding The given encoding.
+     * @param fileFilters The file filters.
+     * @param nonFilteredFileExtensions The extensions which should not being filtered.
+     * @param mavenSession The maven session.
+     * @param rootNode param used for json files
+     */
+    public MavenResourcesExecution( List<Resource> resources, File outputDirectory, MavenProject mavenProject,
+                                    String encoding, List<String> fileFilters, List<String> nonFilteredFileExtensions,
+                                    MavenSession mavenSession, String rootNode )
+    {
+        super( mavenProject, fileFilters, mavenSession );
+        this.encoding = encoding;
+        this.resources = resources;
+        this.outputDirectory = outputDirectory;
+        this.nonFilteredFileExtensions = nonFilteredFileExtensions;
+        this.useDefaultFilterWrappers = true;
+        this.addDefaultExcludes = true;
+        this.resourcesBaseDirectory = mavenProject.getBasedir();
+        this.rootNode = rootNode;
     }
 
     /**
@@ -318,6 +349,24 @@ public class MavenResourcesExecution
                 return interpolatorFilterReader;
             }
         } );
+    }
+
+    /**
+     * get RootNode
+     * @return
+     */
+    public String getRootNode()
+    {
+        return rootNode;
+    }
+
+    /**
+     * set rootNode
+     * @param rootNode
+     */
+    public void setRootNode( String rootNode )
+    {
+        this.rootNode = rootNode;
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/filtering/PropertiesJson.java
+++ b/src/main/java/org/apache/maven/shared/filtering/PropertiesJson.java
@@ -1,0 +1,185 @@
+package org.apache.maven.shared.filtering;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+/**
+ * I added this class to support JSON files MRESOURCES-284
+ * @author <a href="mailto:belmoujahid.i@gmail.com">Imad BELMOUJAHID</a> @ImadBL
+ */
+public class PropertiesJson
+{
+    /**
+     * properties
+     */
+    private final Properties properties;
+
+    /**
+     * default constructor
+     */
+    public PropertiesJson ()
+    {
+        properties = new Properties ();
+    }
+
+    /**
+     *
+     * @return properties
+     */
+    public Properties getProperties ()
+    {
+        return properties;
+    }
+
+    /**
+     *
+     * @param fr
+     * @param useThisRoot
+     * @throws IOException
+     */
+    public void load ( File fr, String useThisRoot )
+            throws IOException
+    {
+        try ( FileReader reader = new FileReader ( fr ) )
+        {
+            for ( Map.Entry<String, String> e
+                    : getPropertiesFromString( IOUtils.toString( reader ), useThisRoot ).entrySet( ) )
+            {
+
+                this.properties.put ( e.getKey (), e.getValue () );
+            }
+        }
+    }
+
+    /**
+     *
+     * @param json
+     * @param useThisRoot
+     * @return
+     * @throws JsonProcessingException
+     */
+    private HashMap<String, String> getPropertiesFromString( String json, String useThisRoot )
+            throws IOException
+    {
+        int i = 0;
+        String str = "", r = "";
+        HashMap<String, String> hashMap = new HashMap<>();
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> keys = new ArrayList<>();
+        JsonNode jsonNode = mapper.readTree( json );
+        getPropertiesFromJsonNode( hashMap, r, i, str, jsonNode, keys, useThisRoot );
+        return hashMap;
+    }
+
+    /**
+     *
+     * @param result
+     * @param r
+     * @param i
+     * @param str
+     * @param jsonNode
+     * @param keys
+     * @param useThisRoot
+     */
+    private void getPropertiesFromJsonNode ( HashMap<String, String> result, String r, int i, String str,
+                                             JsonNode jsonNode, List<String> keys, String useThisRoot )
+    {
+        if ( jsonNode.isObject() )
+        {
+            Iterator<String> fieldNames = jsonNode.fieldNames();
+            while ( fieldNames.hasNext() )
+            {
+                String fieldName = fieldNames.next();
+                keys.add ( fieldName );
+                if ( jsonNode.get( fieldName ).isObject() )
+                {
+                    i++;
+                    if ( i != 1 )
+                    {
+                        if ( str.isEmpty() )
+                        {
+                            str = fieldName;
+                        }
+                        else
+                        {
+                            str = str.concat ( "." ).concat( fieldName );
+                        }
+                    }
+                    else
+                    {
+                        r = fieldName;
+                    }
+                }
+                getPropertiesFromJsonNode ( result, r, i, str, jsonNode.get( fieldName ), keys, useThisRoot );
+            }
+            //str = "";
+            //i = 0;
+        }
+        else if ( jsonNode.isArray () )
+        {
+            ArrayNode arrayField = ( ArrayNode ) jsonNode;
+            for ( JsonNode node : arrayField )
+            {
+                getPropertiesFromJsonNode ( result, r, i, str, node, keys, useThisRoot ) ;
+            }
+        }
+        else
+        {
+            String key2;
+            if ( str.isEmpty () )
+            {
+                key2 = keys.get ( keys.size () - 1 );
+            }
+            else
+            {
+                key2 = str.concat ( "." ).concat ( keys.get ( keys.size() - 1 ) );
+            }
+            String s = r + "." + key2;
+
+            if ( null != useThisRoot && !useThisRoot.isEmpty() )
+            {
+                if ( s.startsWith( useThisRoot + "." ) )
+                {
+                    result.put ( s.replaceFirst( useThisRoot + ".", "" ), jsonNode.textValue(  ) );
+                }
+            }
+            else
+            {
+                result.put ( s, jsonNode.textValue() );
+            }
+
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/shared/filtering/PropertyUtils.java
+++ b/src/main/java/org/apache/maven/shared/filtering/PropertyUtils.java
@@ -32,6 +32,7 @@ import org.apache.maven.shared.utils.StringUtils;
 import org.codehaus.plexus.logging.Logger;
 
 /**
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
  * @author <a href="mailto:kenney@neonics.com">Kenney Westerhof</a>
  * @author William Ferguson
  */
@@ -54,13 +55,14 @@ public final class PropertyUtils
      *
      * @param propFile The property file to load.
      * @param baseProps Properties containing the initial values to substitute into the properties file.
+     * @param rootNode I have added this parameter for new feature with JSON files ### MRESOURCES-284 ###
      * @return Properties object containing the properties in the file with their values fully resolved.
      * @throws IOException if profile does not exist, or cannot be read.
      */
-    public static Properties loadPropertyFile( File propFile, Properties baseProps )
+    public static Properties loadPropertyFile( File propFile, Properties baseProps, String rootNode )
         throws IOException
     {
-        return loadPropertyFile( propFile, baseProps, null );
+        return loadPropertyFile( propFile, baseProps, null, rootNode );
     }
 
     /**
@@ -73,12 +75,14 @@ public final class PropertyUtils
      * @param propFile The property file to load.
      * @param baseProps Properties containing the initial values to substitute into the properties file.
      * @param logger Logger instance
+     * @param rootNode I have added this parameter for new feature with JSON files ### MRESOURCES-284 ###
      * @return Properties object containing the properties in the file with their values fully resolved.
      * @throws IOException if profile does not exist, or cannot be read.
      *
      * @since 3.1.2
      */
-    public static Properties loadPropertyFile( File propFile, Properties baseProps, Logger logger )
+    public static Properties loadPropertyFile( File propFile, Properties baseProps, Logger logger,
+                                               String rootNode )
         throws IOException
     {
         if ( !propFile.exists() )
@@ -90,7 +94,17 @@ public final class PropertyUtils
         
         try ( InputStream inStream = Files.newInputStream( propFile.toPath() ) )
         {
-            fileProps.load( inStream );
+            // I added this control to support JSON files
+            if ( propFile.getName().endsWith( ".json" ) )
+            {
+                PropertiesJson propertiesJson = new PropertiesJson();
+                propertiesJson.load( propFile, rootNode );
+                fileProps.putAll( propertiesJson.getProperties() );
+            }
+            else
+            {
+                fileProps.load( inStream );
+            }
         }
 
         final Properties combinedProps = new Properties();
@@ -122,13 +136,15 @@ public final class PropertyUtils
      * @param propfile The property file to load
      * @param fail whether to throw an exception when the file cannot be loaded or to return null
      * @param useSystemProps whether to incorporate System.getProperties settings into the returned Properties object.
+     * @param rootNode I have added this parameter for new feature with JSON files ### MRESOURCES-284 ###
      * @return the loaded and fully resolved Properties object
      * @throws IOException if profile does not exist, or cannot be read.
      */
-    public static Properties loadPropertyFile( File propfile, boolean fail, boolean useSystemProps )
+    public static Properties loadPropertyFile( File propfile, boolean fail, boolean useSystemProps,
+                                               String rootNode )
         throws IOException
     {
-        return loadPropertyFile( propfile, fail, useSystemProps, null );
+        return loadPropertyFile( propfile, fail, useSystemProps, null, rootNode );
     }
 
     /**
@@ -138,12 +154,14 @@ public final class PropertyUtils
      * @param fail whether to throw an exception when the file cannot be loaded or to return null
      * @param useSystemProps whether to incorporate System.getProperties settings into the returned Properties object.
      * @param logger Logger instance
+     * @param rootNode I have added this parameter for new feature with JSON files ### MRESOURCES-284 ###
      * @return the loaded and fully resolved Properties object
      * @throws IOException if profile does not exist, or cannot be read.
      *
      * @since 3.1.2
      */
-    public static Properties loadPropertyFile( File propfile, boolean fail, boolean useSystemProps, Logger logger )
+    public static Properties loadPropertyFile( File propfile, boolean fail, boolean useSystemProps, Logger logger,
+                                               String rootNode )
         throws IOException
     {
 
@@ -157,7 +175,17 @@ public final class PropertyUtils
         final Properties resolvedProps = new Properties();
         try
         {
-            resolvedProps.putAll( loadPropertyFile( propfile, baseProps, logger ) );
+            // I added this control to support JSON files
+            if ( propfile.getName().endsWith( ".json" ) )
+            {
+                PropertiesJson propertiesJson = new PropertiesJson();
+                propertiesJson.load( propfile, rootNode );
+                resolvedProps.putAll( propertiesJson.getProperties() );
+            }
+            else
+            {
+                resolvedProps.putAll( loadPropertyFile( propfile, baseProps, logger, null ) );
+            }
         }
         catch ( FileNotFoundException e )
         {

--- a/src/test/java/org/apache/maven/shared/filtering/DefaultMavenFileFilterTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/DefaultMavenFileFilterTest.java
@@ -37,7 +37,7 @@ import org.codehaus.plexus.PlexusTestCase;
 
 /**
  * @author Olivier Lamy
- *
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
  */
 public class DefaultMavenFileFilterTest
     extends PlexusTestCase
@@ -53,6 +53,10 @@ public class DefaultMavenFileFilterTest
         Files.deleteIfExists( to.toPath() );
     }
 
+    /**
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
+     * @throws Exception
+     */
     public void testNotOverwriteFile()
         throws Exception
     {
@@ -71,11 +75,15 @@ public class DefaultMavenFileFilterTest
 
         mavenFileFilter.copyFile( from, to, false, null, null );
 
-        Properties properties = PropertyUtils.loadPropertyFile( to, null );
+        Properties properties = PropertyUtils.loadPropertyFile( to, null, null );
         assertEquals( "${pom.version}", properties.getProperty( "version" ) );
 
     }
 
+    /**
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
+     * @throws Exception
+     */
     public void testOverwriteFile()
         throws Exception
     {
@@ -94,7 +102,7 @@ public class DefaultMavenFileFilterTest
 
         mavenFileFilter.copyFile( from, to, false, null, null, true );
 
-        Properties properties = PropertyUtils.loadPropertyFile( to, null );
+        Properties properties = PropertyUtils.loadPropertyFile( to, null, null );
         assertEquals( "older file", properties.getProperty( "version" ) );
 
     }
@@ -124,7 +132,7 @@ public class DefaultMavenFileFilterTest
 
         final Properties filterProperties = new Properties();
 
-        mavenFileFilter.loadProperties( filterProperties, new File( getBasedir() ), filters, new Properties() );
+        mavenFileFilter.loadProperties( filterProperties, new File( getBasedir() ), filters, new Properties(), null );
 
         assertTrue( filterProperties.getProperty( "third_filter_key" ).equals( "first and second" ) );
     }

--- a/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
@@ -39,7 +39,7 @@ import org.codehaus.plexus.interpolation.ValueSource;
 
 /**
  * @author Olivier Lamy
- *
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
  * @since 1.0-beta-1
  */
 public class DefaultMavenResourcesFilteringTest
@@ -273,6 +273,10 @@ public class DefaultMavenResourcesFilteringTest
         assertTrue( filesAreIdentical( initialImageFile, imageFile ) );
     }
 
+    /**
+     * I added a null for rootNode parameter because it is only used with json file @ImadBL
+     * @throws Exception
+     */
     public void testAddingTokens()
         throws Exception
     {
@@ -307,12 +311,16 @@ public class DefaultMavenResourcesFilteringTest
 
         mavenResourcesFiltering.filterResources( mavenResourcesExecution );
         Properties result =
-            PropertyUtils.loadPropertyFile( new File( outputDirectory, "maven-resources-filtering.txt" ), null );
+            PropertyUtils.loadPropertyFile( new File( outputDirectory, "maven-resources-filtering.txt" ), null, null );
         assertFalse( result.isEmpty() );
         assertEquals( mavenProject.getName(), result.get( "pomName" ) );
         assertFiltering( initialImageFile, false, false );
     }
 
+    /**
+     * I added a null for rootNode parameter because it is only used with json file @ImadBL
+     * @throws Exception
+     */
     public void testNoFiltering()
         throws Exception
     {
@@ -340,10 +348,10 @@ public class DefaultMavenResourcesFilteringTest
 
         assertEquals( 7, outputDirectory.listFiles().length );
         Properties result =
-            PropertyUtils.loadPropertyFile( new File( outputDirectory, "empty-maven-resources-filtering.txt" ), null );
+            PropertyUtils.loadPropertyFile( new File( outputDirectory, "empty-maven-resources-filtering.txt" ), null, null );
         assertTrue( result.isEmpty() );
 
-        result = PropertyUtils.loadPropertyFile( new File( outputDirectory, "maven-resources-filtering.txt" ), null );
+        result = PropertyUtils.loadPropertyFile( new File( outputDirectory, "maven-resources-filtering.txt" ), null, null );
         assertFalse( result.isEmpty() );
 
         assertEquals( "${pom.version}", result.get( "version" ) );
@@ -774,6 +782,8 @@ public class DefaultMavenResourcesFilteringTest
 
     /**
      * unit test for MSHARED-81 : https://issues.apache.org/jira/browse/MSHARED-81
+     *
+     * I added a null for rootNode parameter because it is only used with json file @ImadBL
      */
     @SuppressWarnings( "serial" )
     public void testMSHARED81()
@@ -809,22 +819,22 @@ public class DefaultMavenResourcesFilteringTest
 
         mavenResourcesFiltering.filterResources( mavenResourcesExecution );
 
-        Properties filteredResult = PropertyUtils.loadPropertyFile( new File( output, "filtered.properties" ), null );
+        Properties filteredResult = PropertyUtils.loadPropertyFile( new File( output, "filtered.properties" ), null, null );
 
         Properties expectedFilteredResult =
             PropertyUtils.loadPropertyFile( new File( getBasedir() + "/src/test/units-files/MSHARED-81",
                                                       "expected-filtered.properties" ),
-                                            null );
+                                            null, null );
 
         assertEquals( expectedFilteredResult, filteredResult );
 
         Properties nonFilteredResult =
-            PropertyUtils.loadPropertyFile( new File( output, "unfiltered.properties" ), null );
+            PropertyUtils.loadPropertyFile( new File( output, "unfiltered.properties" ), null, null );
 
         Properties expectedNonFilteredResult =
             PropertyUtils.loadPropertyFile( new File( getBasedir() + "/src/test/units-files/MSHARED-81/resources",
                                                       "unfiltered.properties" ),
-                                            null );
+                                            null, null );
 
         assertTrue( nonFilteredResult.equals( expectedNonFilteredResult ) );
     }
@@ -868,6 +878,8 @@ public class DefaultMavenResourcesFilteringTest
 
     /**
      * unit test for edge cases : https://issues.apache.org/jira/browse/MSHARED-228
+     *
+     * I added a null for rootNode parameter because it is only used with json file @ImadBL
      */
     @SuppressWarnings( "serial" )
     public void testEdgeCases()
@@ -905,22 +917,22 @@ public class DefaultMavenResourcesFilteringTest
 
         mavenResourcesFiltering.filterResources( mavenResourcesExecution );
 
-        Properties filteredResult = PropertyUtils.loadPropertyFile( new File( output, "filtered.properties" ), null );
+        Properties filteredResult = PropertyUtils.loadPropertyFile( new File( output, "filtered.properties" ), null, null );
 
         Properties expectedFilteredResult =
             PropertyUtils.loadPropertyFile( new File( getBasedir() + "/src/test/units-files/edge-cases",
                                                       "expected-filtered.properties" ),
-                                            null );
+                                            null, null );
 
         assertEquals( expectedFilteredResult, filteredResult );
 
         Properties nonFilteredResult =
-            PropertyUtils.loadPropertyFile( new File( output, "unfiltered.properties" ), null );
+            PropertyUtils.loadPropertyFile( new File( output, "unfiltered.properties" ), null, null );
 
         Properties expectedNonFilteredResult =
             PropertyUtils.loadPropertyFile( new File( getBasedir() + "/src/test/units-files/edge-cases/resources",
                                                       "unfiltered.properties" ),
-                                            null );
+                                            null, null );
 
         assertTrue( nonFilteredResult.equals( expectedNonFilteredResult ) );
     }

--- a/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.logging.Logger;
 
 /**
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
  * @author Olivier Lamy
  * @since 1.0-beta-1
  *
@@ -37,6 +38,54 @@ public class PropertyUtilsTest
     extends PlexusTestCase
 {
     private static File testDirectory = new File( getBasedir(), "target/test-classes/" );
+
+    public void testBasicForJsonFile() throws IOException {
+
+        File basicProp = new File( testDirectory, "propertyutils-test.json" );
+        basicProp.deleteOnExit();
+
+        if ( basicProp.exists() )
+        {
+            basicProp.delete();
+        }
+
+        basicProp.createNewFile();
+        try ( FileWriter writer = new FileWriter( basicProp ) )
+        {
+            writer.write( "{ \"dev\" : { \"type\" : \"toto\", \"key2\" : \"value2\", " +
+                    "\"key3\" : {\"key4\" : \"value4\" } }, \"qualif\" : { \"type2\" : " +
+                    "\"toto1\", \"key5\" : \"value7\", \"key7\" : {\"key8\" : \"toto\"}}}\n" );
+            writer.flush();
+        }
+
+        Properties prop2 = PropertyUtils.loadPropertyFile( basicProp, false, false, null );
+        assertTrue( prop2.getProperty( "dev.type" ).equals( "toto" ) );
+        assertTrue( prop2.getProperty( "dev.key2" ).equals( "value2" ) );
+    }
+
+    public void testBasicForJsonFileWithrootNode() throws IOException {
+
+        File basicProp = new File( testDirectory, "propertyutils-test.json" );
+        basicProp.deleteOnExit();
+
+        if ( basicProp.exists() )
+        {
+            basicProp.delete();
+        }
+
+        basicProp.createNewFile();
+        try ( FileWriter writer = new FileWriter( basicProp ) )
+        {
+            writer.write( "{ \"dev\" : { \"type\" : \"toto\", \"key2\" : \"value2\", " +
+                    "\"key3\" : {\"key4\" : \"value4\" } }, \"qualif\" : { \"type2\" : " +
+                    "\"toto1\", \"key5\" : \"value7\", \"key7\" : {\"key8\" : \"toto\"}}}\n" );
+            writer.flush();
+        }
+
+        Properties prop2 = PropertyUtils.loadPropertyFile( basicProp, false, false, "dev" );
+        assertTrue( prop2.getProperty( "type" ).equals( "toto" ) );
+        assertTrue( prop2.getProperty( "key2" ).equals( "value2" ) );
+    }
 
     public void testBasic()
         throws Exception
@@ -57,11 +106,15 @@ public class PropertyUtilsTest
             writer.flush();
         }
 
-        Properties prop = PropertyUtils.loadPropertyFile( basicProp, false, false );
+        Properties prop = PropertyUtils.loadPropertyFile( basicProp, false, false, null );
         assertTrue( prop.getProperty( "key" ).equals( "gani_man" ) );
         assertTrue( prop.getProperty( "ghost" ).equals( "${non_existent}" ) );
     }
 
+    /**
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
+     * @throws Exception
+     */
     public void testSystemProperties()
         throws Exception
     {
@@ -79,10 +132,14 @@ public class PropertyUtilsTest
             writer.flush();
         }
 
-        Properties prop = PropertyUtils.loadPropertyFile( systemProp, false, true );
+        Properties prop = PropertyUtils.loadPropertyFile( systemProp, false, true, null );
         assertTrue( prop.getProperty( "key" ).equals( System.getProperty( "user.dir" ) ) );
     }
 
+    /**
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
+     * @throws Exception
+     */
     public void testException()
         throws Exception
     {
@@ -92,7 +149,7 @@ public class PropertyUtilsTest
 
         try
         {
-            PropertyUtils.loadPropertyFile( nonExistent, true, false );
+            PropertyUtils.loadPropertyFile( nonExistent, true, false, null );
             assertTrue( "Exception failed", false );
         }
         catch ( Exception ex )
@@ -101,6 +158,10 @@ public class PropertyUtilsTest
         }
     }
 
+    /**
+     * I added a null for rootNode parameter because it is only used with json file @ImadBL
+     * @throws Exception
+     */
     public void testloadpropertiesFile()
         throws Exception
     {
@@ -108,7 +169,7 @@ public class PropertyUtilsTest
         Properties baseProps = new Properties();
         baseProps.put( "pom.version", "realVersion" );
 
-        Properties interpolated = PropertyUtils.loadPropertyFile( propertyFile, baseProps );
+        Properties interpolated = PropertyUtils.loadPropertyFile( propertyFile, baseProps, null );
         assertEquals( "realVersion", interpolated.get( "version" ) );
         assertEquals( "${foo}", interpolated.get( "foo" ) );
         assertEquals( "realVersion", interpolated.get( "bar" ) );
@@ -117,7 +178,7 @@ public class PropertyUtilsTest
 
     /**
      * Test case to reproduce MSHARED-417
-     *
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
      * @throws IOException if problem writing file
      */
     public void testCircularReferences()
@@ -140,7 +201,7 @@ public class PropertyUtilsTest
 
         MockLogger logger = new MockLogger();
 
-        Properties prop = PropertyUtils.loadPropertyFile( basicProp, null, logger );
+        Properties prop = PropertyUtils.loadPropertyFile( basicProp, null, logger, null );
         assertEquals( "${test2}", prop.getProperty( "test" ) );
         assertEquals( "${test2}", prop.getProperty( "test2" ) );
         assertEquals( 2, logger.warnMsgs.size() );
@@ -150,7 +211,7 @@ public class PropertyUtilsTest
 
     /**
      * Test case to reproduce MSHARED-417
-     *
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
      * @throws IOException if problem writing file
      */
     public void testCircularReferences3Vars()
@@ -174,7 +235,7 @@ public class PropertyUtilsTest
 
         MockLogger logger = new MockLogger();
 
-        Properties prop = PropertyUtils.loadPropertyFile( basicProp, null, logger );
+        Properties prop = PropertyUtils.loadPropertyFile( basicProp, null, logger, null );
         assertEquals( "${test2}", prop.getProperty( "test" ) );
         assertEquals( "${test3}", prop.getProperty( "test2" ) );
         assertEquals( "${test}", prop.getProperty( "test3" ) );


### PR DESCRIPTION
Hi,

This concerns the **maven-resources-plugin** (3.2.1-SNAPSHOT) and **maven-filtering** (3.3.0-SNAPSHOT) plugins.
with this evolution it is now possible to add configuration files with json format. the second part of this evolution is to have to use a one configuration json file for all environments (dev, preprod, prod...etc )
for more example check: MRESOURCES-284

please note that you must accept the PR first for **maven-filtering** (3.3.0-SNAPSHOT) 
because **maven-resources-plugin** (3.2.1-SNAPSHOT) need **maven-filtering** (3.3.0-SNAPSHOT) 

if you have any questions do not hesitate, hoping that I have detailed well

Best regards
Imad BELMOUJAHID
@ImadBL