### PR TITLE
[MSHARED-1175] Copying x resources from rel/path to rel/path

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
+++ b/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
@@ -220,17 +220,25 @@ public class DefaultMavenResourcesFiltering implements MavenResourcesFiltering {
 
             List<String> includedFiles = Arrays.asList(scanner.getIncludedFiles());
 
-            File basedir =
-                    mavenResourcesExecution.getMavenProject().getBasedir().getAbsoluteFile();
-            LOGGER.info("Copying " + includedFiles.size() + " resource" + (includedFiles.size() > 1 ? "s" : "")
-                    + " from "
-                    + basedir.toPath()
-                            .relativize(resourceDirectory.getAbsoluteFile().toPath())
-                    + " to "
-                    + basedir.toPath()
-                            .relativize(getDestinationFile(outputDirectory, targetPath, "", mavenResourcesExecution)
-                                    .getAbsoluteFile()
-                                    .toPath()));
+            try {
+                Path basedir = mavenResourcesExecution
+                        .getMavenProject()
+                        .getBasedir()
+                        .getAbsoluteFile()
+                        .toPath();
+                Path destination = getDestinationFile(outputDirectory, targetPath, "", mavenResourcesExecution)
+                        .getAbsoluteFile()
+                        .toPath();
+                LOGGER.info("Copying " + includedFiles.size() + " resource" + (includedFiles.size() > 1 ? "s" : "")
+                        + " from "
+                        + basedir.relativize(resourceDirectory.getAbsoluteFile().toPath())
+                        + " to "
+                        + basedir.relativize(destination));
+            } catch (Exception e) {
+                // be foolproof: if for ANY reason throws, do not abort, just fall back to old message
+                LOGGER.info("Copying " + includedFiles.size() + " resource" + (includedFiles.size() > 1 ? "s" : "")
+                        + (targetPath == null ? "" : " to " + targetPath));
+            }
 
             for (String name : includedFiles) {
 

--- a/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
+++ b/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
@@ -220,8 +220,17 @@ public class DefaultMavenResourcesFiltering implements MavenResourcesFiltering {
 
             List<String> includedFiles = Arrays.asList(scanner.getIncludedFiles());
 
+            File basedir =
+                    mavenResourcesExecution.getMavenProject().getBasedir().getAbsoluteFile();
             LOGGER.info("Copying " + includedFiles.size() + " resource" + (includedFiles.size() > 1 ? "s" : "")
-                    + (targetPath == null ? "" : " to " + targetPath));
+                    + " from "
+                    + basedir.toPath()
+                            .relativize(resourceDirectory.getAbsoluteFile().toPath())
+                    + " to "
+                    + basedir.toPath()
+                            .relativize(getDestinationFile(outputDirectory, targetPath, "", mavenResourcesExecution)
+                                    .getAbsoluteFile()
+                                    .toPath()));
 
             for (String name : includedFiles) {
 

--- a/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
@@ -43,7 +43,7 @@ import org.codehaus.plexus.interpolation.ValueSource;
 public class DefaultMavenResourcesFilteringTest extends TestSupport {
 
     private File outputDirectory = new File(getBasedir(), "target/DefaultMavenResourcesFilteringTest");
-    private File baseDir = new File("c:\\foo\\bar");
+    private File baseDir = new File(getBasedir());
     private StubMavenProject mavenProject = new StubMavenProject(baseDir);
     private MavenResourcesFiltering mavenResourcesFiltering;
 
@@ -431,7 +431,7 @@ public class DefaultMavenResourcesFilteringTest extends TestSupport {
     }
 
     public void testFlattenDirectoryStructure() throws Exception {
-        File baseDir = new File("c:\\foo\\bar");
+        File baseDir = new File(getBasedir());
         StubMavenProject mavenProject = new StubMavenProject(baseDir);
         mavenProject.setVersion("1.0");
         mavenProject.setGroupId("org.apache");
@@ -476,7 +476,7 @@ public class DefaultMavenResourcesFilteringTest extends TestSupport {
     }
 
     public void testFlattenDirectoryStructureWithoutOverride() throws Exception {
-        File baseDir = new File("c:\\foo\\bar");
+        File baseDir = new File(getBasedir());
         StubMavenProject mavenProject = new StubMavenProject(baseDir);
         mavenProject.setVersion("1.0");
         mavenProject.setGroupId("org.apache");

--- a/src/test/java/org/apache/maven/shared/filtering/EscapeStringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/EscapeStringTest.java
@@ -47,7 +47,7 @@ public class EscapeStringTest extends TestSupport {
     }
 
     public void testEscape() throws Exception {
-        File baseDir = new File("c:\\foo\\bar");
+        File baseDir = new File(getBasedir());
         StubMavenProject mavenProject = new StubMavenProject(baseDir);
         mavenProject.setVersion("1.0");
         mavenProject.setGroupId("org.apache");

--- a/src/test/java/org/apache/maven/shared/filtering/MuliLinesMavenResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/MuliLinesMavenResourcesFilteringTest.java
@@ -49,7 +49,7 @@ public class MuliLinesMavenResourcesFilteringTest extends TestSupport {
      * @throws Exception
      */
     public void testFilteringTokenOnce() throws Exception {
-        File baseDir = new File("c:\\foo\\bar");
+        File baseDir = new File(getBasedir());
         StubMavenProject mavenProject = new StubMavenProject(baseDir);
         mavenProject.setVersion("1.0");
         mavenProject.setGroupId("org.apache");


### PR DESCRIPTION
Currently, default destination directory is either implicit or shown with full path, and from is hidden:

```
[INFO] — maven-resources-plugin:3.3.0:resources (default-resources) @ demo —
[INFO] Copying 3 resources
[INFO] Copying 70 resources to /noisy/path/to/project/target/site-src

[INFO] — maven-resources-plugin:3.3.0:testResources (default-testResources) @ demo —
[INFO] Copying 39 resources
```

It would be much clearer to always see info as relative:

```
[INFO] — maven-resources-plugin:3.3.1-SNAPSHOT:resources (default-resources) @ demo —
[INFO] Copying 3 resources from src/main/resources to target/classes
[INFO] Copying 70 resources from src/site to target/site-src

[INFO] — maven-resources-plugin:3.3.1-SNAPSHOT:testResources (default-testResources) @ demo —
[INFO] Copying 39 resources from src/test/resources to target/test-classes
```

---

https://issues.apache.org/jira/browse/MSHARED-1175
