### PR TITLE
[MSHARED-1213] Bug: filtering existing but 0 byte file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>src/test/units-files/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
       </plugin>

--- a/src/main/java/org/apache/maven/shared/filtering/FilteringUtils.java
+++ b/src/main/java/org/apache/maven/shared/filtering/FilteringUtils.java
@@ -361,13 +361,17 @@ public final class FilteringUtils {
 
                             if (!writing) {
                                 existingRead = existing.read(existingBytes.array(), 0, newBytes.remaining());
-                                ((Buffer) existingBytes).position(existingRead);
-                                ((Buffer) existingBytes).flip();
+                                if (existingRead == -1) {
+                                    writing = true; // EOF
+                                } else {
+                                    ((Buffer) existingBytes).position(existingRead);
+                                    ((Buffer) existingBytes).flip();
 
-                                if (newBytes.compareTo(existingBytes) != 0) {
-                                    writing = true;
-                                    if (existingRead > 0) {
-                                        existing.seek(existing.getFilePointer() - existingRead);
+                                    if (newBytes.compareTo(existingBytes) != 0) {
+                                        writing = true;
+                                        if (existingRead > 0) {
+                                            existing.seek(existing.getFilePointer() - existingRead);
+                                        }
                                     }
                                 }
                             }

--- a/src/test/java/org/apache/maven/shared/filtering/FilteringUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/FilteringUtilsTest.java
@@ -18,6 +18,14 @@
  */
 package org.apache.maven.shared.filtering;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -28,7 +36,29 @@ import static org.junit.Assert.assertEquals;
  * @since 1.0
  *
  */
-public class FilteringUtilsTest {
+public class FilteringUtilsTest extends TestSupport {
+    private static File testDirectory = new File(getBasedir(), "target/test-classes/");
+
+    @Test
+    public void testCopy() throws IOException {
+        File fromFile = new File(getBasedir() + "/src/test/units-files/MSHARED-1213/enunciate.xml");
+        File toFile = new File(testDirectory, "MSHARED-1213-enunciate.xml");
+        Files.copy(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        FilteringUtils.copyFile(
+                fromFile,
+                toFile,
+                "UTF-8",
+                new FilterWrapper[] {
+                    new FilterWrapper() {
+                        @Override
+                        public Reader getReader(Reader fileReader) {
+                            return fileReader;
+                        }
+                    }
+                },
+                false);
+    }
+
     @Test
     public void testEscapeWindowsPathStartingWithDrive() {
         assertEquals("C:\\\\Users\\\\Administrator", FilteringUtils.escapeWindowsPath("C:\\Users\\Administrator"));

--- a/src/test/java/org/apache/maven/shared/filtering/FilteringUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/FilteringUtilsTest.java
@@ -22,9 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 import org.junit.Test;
 
@@ -40,10 +38,10 @@ public class FilteringUtilsTest extends TestSupport {
     private static File testDirectory = new File(getBasedir(), "target/test-classes/");
 
     @Test
-    public void testCopy() throws IOException {
+    public void testMSHARED1213CopyWithTargetAlreadyExisting0ByteFile() throws IOException {
         File fromFile = new File(getBasedir() + "/src/test/units-files/MSHARED-1213/enunciate.xml");
         File toFile = new File(testDirectory, "MSHARED-1213-enunciate.xml");
-        Files.copy(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        Files.write(toFile.toPath(), "".getBytes(StandardCharsets.UTF_8));
         FilteringUtils.copyFile(
                 fromFile,
                 toFile,

--- a/src/test/java/org/apache/maven/shared/filtering/FilteringUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/FilteringUtilsTest.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -55,6 +57,55 @@ public class FilteringUtilsTest extends TestSupport {
                     }
                 },
                 false);
+        Assert.assertEquals(
+                Files.readAllLines(fromFile.toPath(), StandardCharsets.UTF_8),
+                Files.readAllLines(toFile.toPath(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testMSHARED1213CopyWithTargetAlreadyExistingJunkFile() throws IOException {
+        File fromFile = new File(getBasedir() + "/src/test/units-files/MSHARED-1213/enunciate.xml");
+        File toFile = new File(testDirectory, "MSHARED-1213-enunciate.xml");
+        Files.write(toFile.toPath(), "junk".getBytes(StandardCharsets.UTF_8));
+        FilteringUtils.copyFile(
+                fromFile,
+                toFile,
+                "UTF-8",
+                new FilterWrapper[] {
+                    new FilterWrapper() {
+                        @Override
+                        public Reader getReader(Reader fileReader) {
+                            return fileReader;
+                        }
+                    }
+                },
+                false);
+        Assert.assertEquals(
+                Files.readAllLines(fromFile.toPath(), StandardCharsets.UTF_8),
+                Files.readAllLines(toFile.toPath(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testMSHARED1213CopyWithTargetAlreadyExistingSameFile() throws IOException {
+        File fromFile = new File(getBasedir() + "/src/test/units-files/MSHARED-1213/enunciate.xml");
+        File toFile = new File(testDirectory, "MSHARED-1213-enunciate.xml");
+        Files.copy(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        FilteringUtils.copyFile(
+                fromFile,
+                toFile,
+                "UTF-8",
+                new FilterWrapper[] {
+                    new FilterWrapper() {
+                        @Override
+                        public Reader getReader(Reader fileReader) {
+                            return fileReader;
+                        }
+                    }
+                },
+                false);
+        Assert.assertEquals(
+                Files.readAllLines(fromFile.toPath(), StandardCharsets.UTF_8),
+                Files.readAllLines(toFile.toPath(), StandardCharsets.UTF_8));
     }
 
     @Test

--- a/src/test/units-files/MSHARED-1213/enunciate.xml
+++ b/src/test/units-files/MSHARED-1213/enunciate.xml
@@ -1,0 +1,10 @@
+<enunciate xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.15.0.xsd">
+
+  <modules>
+    <jackson>
+      <mixin target="com.webcohesion.enunciate.examples.jaxrsjackson.genealogy.data.CompoundId"
+             source="com.webcohesion.enunciate.examples.jaxrsjackson.genealogy.data.CompoundIdMixin"/>
+    </jackson>
+  </modules>
+
+</enunciate>


### PR DESCRIPTION
Fix the bug, that manifested when `FilteringUtils.copyFile` was invoked with target existing as 0 byte file, it produced strange error like this:

```
Caused by: java.lang.IllegalArgumentException: newPosition < 0: (-1 < 0)
    at java.nio.Buffer.createPositionException (Buffer.java:318)
    at java.nio.Buffer.position (Buffer.java:293)
    at java.nio.ByteBuffer.position (ByteBuffer.java:1094)
    at java.nio.ByteBuffer.position (ByteBuffer.java:262)
    at org.apache.maven.shared.filtering.FilteringUtils.copyFile (FilteringUtils.java:425)
    at org.apache.maven.shared.filtering.DefaultMavenFileFilter.copyFile (DefaultMavenFileFilter.java:102)
    at org.apache.maven.shared.filtering.DefaultMavenFileFilter.copyFile (DefaultMavenFileFilter.java:85)
    at org.apache.maven.shared.filtering.DefaultMavenFileFilter.copyFile (DefaultMavenFileFilter.java:66) 
```

---

https://issues.apache.org/jira/browse/MSHARED-1213