### PR TITLE
[MSHARED-1216] Use caching output stream

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/DefaultMavenFileFilter.java
+++ b/src/main/java/org/apache/maven/shared/filtering/DefaultMavenFileFilter.java
@@ -82,19 +82,6 @@ public class DefaultMavenFileFilter extends BaseFilter implements MavenFileFilte
     @Override
     public void copyFile(File from, File to, boolean filtering, List<FilterWrapper> filterWrappers, String encoding)
             throws MavenFilteringException {
-        // overwrite forced to false to preserve backward comp
-        copyFile(from, to, filtering, filterWrappers, encoding, false);
-    }
-
-    @Override
-    public void copyFile(
-            File from,
-            File to,
-            boolean filtering,
-            List<FilterWrapper> filterWrappers,
-            String encoding,
-            boolean overwrite)
-            throws MavenFilteringException {
         try {
             if (filtering) {
                 if (getLogger().isDebugEnabled()) {
@@ -106,7 +93,7 @@ public class DefaultMavenFileFilter extends BaseFilter implements MavenFileFilte
                 if (getLogger().isDebugEnabled()) {
                     getLogger().debug("copy " + from.getPath() + " to " + to.getPath());
                 }
-                FilteringUtils.copyFile(from, to, encoding, new FilterWrapper[0], overwrite);
+                FilteringUtils.copyFile(from, to, encoding, new FilterWrapper[0], false);
             }
 
             buildContext.refresh(to);
@@ -116,5 +103,19 @@ public class DefaultMavenFileFilter extends BaseFilter implements MavenFileFilte
                             + e.getClass().getSimpleName(),
                     e);
         }
+    }
+
+    @Override
+    @Deprecated
+    public void copyFile(
+            File from,
+            File to,
+            boolean filtering,
+            List<FilterWrapper> filterWrappers,
+            String encoding,
+            boolean overwrite)
+            throws MavenFilteringException {
+        // overwrite forced to false to preserve backward comp
+        copyFile(from, to, filtering, filterWrappers, encoding);
     }
 }

--- a/src/main/java/org/apache/maven/shared/filtering/MavenFileFilter.java
+++ b/src/main/java/org/apache/maven/shared/filtering/MavenFileFilter.java
@@ -78,10 +78,12 @@ public interface MavenFileFilter extends DefaultFilterInfo {
      * @param filtering true to apply filtering
      * @param filterWrappers The filters to be applied.
      * @param encoding The encoding to use
-     * @param overwrite Overwrite to file ?
+     * @param overwrite unused
      * @throws MavenFilteringException In case of an error.
      * @since 1.0-beta-2
+     * @deprecated use {@link #copyFile(File, File, boolean, List, String)} instead
      */
+    @Deprecated
     void copyFile(
             File from,
             File to,

--- a/src/test/java/org/apache/maven/shared/filtering/DefaultMavenFileFilterTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/DefaultMavenFileFilterTest.java
@@ -49,26 +49,6 @@ public class DefaultMavenFileFilterTest extends TestSupport {
         Files.deleteIfExists(to.toPath());
     }
 
-    public void testNotOverwriteFile() throws Exception {
-        MavenFileFilter mavenFileFilter = lookup(MavenFileFilter.class);
-
-        File from = new File(getBasedir(), "src/test/units-files/reflection-test.properties");
-
-        mavenFileFilter.copyFile(from, to, false, null, null);
-
-        from = new File(getBasedir(), "src/test/units-files/reflection-test-older.properties");
-
-        // very old file :-)
-        from.setLastModified(1);
-
-        to.setLastModified(System.currentTimeMillis());
-
-        mavenFileFilter.copyFile(from, to, false, null, null);
-
-        Properties properties = PropertyUtils.loadPropertyFile(to, null);
-        assertEquals("${pom.version}", properties.getProperty("version"));
-    }
-
     public void testOverwriteFile() throws Exception {
         MavenFileFilter mavenFileFilter = lookup(MavenFileFilter.class);
 
@@ -83,7 +63,7 @@ public class DefaultMavenFileFilterTest extends TestSupport {
 
         to.setLastModified(System.currentTimeMillis());
 
-        mavenFileFilter.copyFile(from, to, false, null, null, true);
+        mavenFileFilter.copyFile(from, to, false, null, null);
 
         Properties properties = PropertyUtils.loadPropertyFile(to, null);
         assertEquals("older file", properties.getProperty("version"));


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MSHARED-1216

Use a caching output stream when copying / filtering resources. This has the advantage of not modifying the file if the content has not changed (and thus will avoid having to compile / process / package the resource again and having a cascading effect in the reactor to downstream dependencies).
This deprecates the `overwrite` flag introduced by [MSHARED-67](https://issues.apache.org/jira/browse/MSHARED-67) / [MRESOURCES-21](https://issues.apache.org/jira/browse/MRESOURCES-21).

The change has the same effect as if always using `overwrite=true`, but only if the content has changed.  If the content is unchanged, the file will not be modified and will not trigger downstream processing based on last modified time.  Note that the `overwrite` flag was only effective when _not_ filtering, which was incoherent too.
