### PR TITLE
Prefer commons lang to plexus utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
       <artifactId>commons-io</artifactId>
       <version>2.11.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/org/apache/maven/shared/filtering/FilteringUtils.java
+++ b/src/main/java/org/apache/maven/shared/filtering/FilteringUtils.java
@@ -37,7 +37,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
-import org.codehaus.plexus.util.Os;
+import org.apache.commons.lang3.SystemUtils;
 
 /**
  * @author Olivier Lamy
@@ -117,7 +117,7 @@ public final class FilteringUtils {
         }
 
         // deal with absolute files
-        if (filenm.startsWith(File.separator) || (Os.isFamily(Os.FAMILY_WINDOWS) && filenm.indexOf(":") > 0)) {
+        if (filenm.startsWith(File.separator) || (SystemUtils.IS_OS_WINDOWS && filenm.indexOf(":") > 0)) {
             File file = new File(filenm);
 
             try {


### PR DESCRIPTION
In this case, the commons lang solution is also simpler and faster, as well as being better supported. 