### PR TITLE
[MSHARED-1290] Fix PropertyUtils cycle detection results in false positives

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/PropertyUtils.java
+++ b/src/main/java/org/apache/maven/shared/filtering/PropertyUtils.java
@@ -218,10 +218,10 @@ public final class PropertyUtils {
                 // else prefix the original string with the
                 // resolved property ( so it can be parsed further )
                 // taking recursion into account.
-                if (nv == null || nv.equals(k) || k.equals(nk)) {
+                if (nv == null || k.equals(nk)) {
                     ret.append("${").append(nk).append("}");
                 } else {
-                    v = nv + v;
+                    v = nv + v.replace("${" + nk + "}", nv);
                 }
             }
         }

--- a/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
@@ -59,7 +59,7 @@ public class PropertyUtilsTest extends TestSupport {
         }
 
         Properties properties = PropertyUtils.loadPropertyFile(systemProperties, false, true);
-        assertEquals(properties.getProperty("key"), System.getProperty("user.dir"));
+        assertEquals(System.getProperty("user.dir"), properties.getProperty("key"));
     }
 
     public void testException() throws Exception {

--- a/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
@@ -38,50 +38,44 @@ public class PropertyUtilsTest extends TestSupport {
     private static File testDirectory = new File(getBasedir(), "target/test-classes/");
 
     public void testBasic() throws Exception {
-        File basicProp = File.createTempFile("basic", ".properties");
+        File basicProperties = File.createTempFile("basic", ".properties");
+        basicProperties.deleteOnExit();
 
-        try {
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(basicProp), StandardCharsets.UTF_8)) {
-                writer.write("ghost=${non_existent}\n");
-                writer.write("key=${untat_na_damgo}\n");
-                writer.write("untat_na_damgo=gani_man\n");
-                writer.flush();
-            }
-
-            Logger logger = mock(Logger.class);
-            Properties prop = PropertyUtils.loadPropertyFile(basicProp, false, false, logger);
-            assertTrue(prop.getProperty("key").equals("gani_man"));
-            assertTrue(prop.getProperty("ghost").equals("${non_existent}"));
-        } finally {
-            basicProp.delete();
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(basicProperties), StandardCharsets.UTF_8)) {
+            writer.write("ghost=${non_existent}\n");
+            writer.write("key=${untat_na_damgo}\n");
+            writer.write("untat_na_damgo=gani_man\n");
+            writer.flush();
         }
+
+        Logger logger = mock(Logger.class);
+        Properties properties = PropertyUtils.loadPropertyFile(basicProperties, false, false, logger);
+        assertEquals("gani_man", properties.getProperty("key"));
+        assertEquals("${non_existent}", properties.getProperty("ghost"));
     }
 
     public void testSystemProperties() throws Exception {
-        File systemProp = File.createTempFile("system", ".properties");
+        File systemProperties = File.createTempFile("system", ".properties");
+        systemProperties.deleteOnExit();
 
-        try {
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(systemProp), StandardCharsets.UTF_8)) {
-                writer.write("key=${user.dir}");
-                writer.flush();
-            }
-
-            Logger logger = mock(Logger.class);
-            Properties prop = PropertyUtils.loadPropertyFile(systemProp, false, true, logger);
-            assertTrue(prop.getProperty("key").equals(System.getProperty("user.dir")));
-        } finally {
-            systemProp.delete();
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(systemProperties), StandardCharsets.UTF_8)) {
+            writer.write("key=${user.dir}");
+            writer.flush();
         }
+
+        Logger logger = mock(Logger.class);
+        Properties properties = PropertyUtils.loadPropertyFile(systemProperties, false, true, logger);
+        assertEquals(properties.getProperty("key"), System.getProperty("user.dir"));
     }
 
     public void testException() throws Exception {
         File nonExistent = new File(testDirectory, "not_existent_file");
 
-        assertFalse("property file exist: " + nonExistent.toString(), nonExistent.exists());
+        assertFalse("property file exist: " + nonExistent, nonExistent.exists());
 
         try {
             PropertyUtils.loadPropertyFile(nonExistent, true, false);
-            assertTrue("Exception failed", false);
+            fail("Expected exception not thrown");
         } catch (Exception ex) {
             // exception ok
         }
@@ -89,11 +83,11 @@ public class PropertyUtilsTest extends TestSupport {
 
     public void testLoadPropertiesFile() throws Exception {
         File propertyFile = new File(getBasedir() + "/src/test/units-files/propertyutils-test.properties");
-        Properties baseProps = new Properties();
-        baseProps.put("pom.version", "realVersion");
+        Properties baseProperties = new Properties();
+        baseProperties.put("pom.version", "realVersion");
 
         Logger logger = mock(Logger.class);
-        Properties interpolated = PropertyUtils.loadPropertyFile(propertyFile, baseProps, logger);
+        Properties interpolated = PropertyUtils.loadPropertyFile(propertyFile, baseProperties, logger);
         assertEquals("realVersion", interpolated.get("version"));
         assertEquals("${foo}", interpolated.get("foo"));
         assertEquals("realVersion", interpolated.get("bar"));
@@ -106,22 +100,19 @@ public class PropertyUtilsTest extends TestSupport {
      * @throws IOException if problem writing file
      */
     public void testCircularReferences() throws IOException {
-        File circularProp = File.createTempFile("circular", ".properties");
+        File circularProperties = File.createTempFile("circular", ".properties");
+        circularProperties.deleteOnExit();
 
-        try {
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(circularProp), StandardCharsets.UTF_8)) {
-                writer.write("test=${test2}\n");
-                writer.write("test2=${test2}\n");
-                writer.flush();
-            }
-
-            Logger logger = mock(Logger.class);
-            Properties prop = PropertyUtils.loadPropertyFile(circularProp, null, logger);
-            assertEquals("${test2}", prop.getProperty("test"));
-            assertEquals("${test2}", prop.getProperty("test2"));
-        } finally {
-            circularProp.delete();
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(circularProperties), StandardCharsets.UTF_8)) {
+            writer.write("test=${test2}\n");
+            writer.write("test2=${test2}\n");
+            writer.flush();
         }
+
+        Logger logger = mock(Logger.class);
+        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null, logger);
+        assertEquals("${test2}", properties.getProperty("test"));
+        assertEquals("${test2}", properties.getProperty("test2"));
     }
 
     /**
@@ -130,64 +121,55 @@ public class PropertyUtilsTest extends TestSupport {
      * @throws IOException if problem writing file
      */
     public void testCircularReferences3Vars() throws IOException {
-        File circularProp = File.createTempFile("circular", ".properties");
+        File circularProperties = File.createTempFile("circular", ".properties");
+        circularProperties.deleteOnExit();
 
-        try {
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(circularProp), StandardCharsets.UTF_8)) {
-                writer.write("test=${test2}\n");
-                writer.write("test2=${test3}\n");
-                writer.write("test3=${test}\n");
-                writer.flush();
-            }
-
-            Logger logger = mock(Logger.class);
-            Properties prop = PropertyUtils.loadPropertyFile(circularProp, null, logger);
-            assertEquals("${test2}", prop.getProperty("test"));
-            assertEquals("${test3}", prop.getProperty("test2"));
-            assertEquals("${test}", prop.getProperty("test3"));
-        } finally {
-            circularProp.delete();
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(circularProperties), StandardCharsets.UTF_8)) {
+            writer.write("test=${test2}\n");
+            writer.write("test2=${test3}\n");
+            writer.write("test3=${test}\n");
+            writer.flush();
         }
+
+        Logger logger = mock(Logger.class);
+        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null, logger);
+        assertEquals("${test2}", properties.getProperty("test"));
+        assertEquals("${test3}", properties.getProperty("test2"));
+        assertEquals("${test}", properties.getProperty("test3"));
     }
 
     public void testNonCircularReferences1Var3Times() throws IOException {
-        File circularProp = File.createTempFile("non-circular", ".properties");
+        File circularProperties = File.createTempFile("non-circular", ".properties");
+        circularProperties.deleteOnExit();
 
-        try {
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(circularProp), StandardCharsets.UTF_8)) {
-                writer.write("depends=p1 >= ${version}, p2 >= ${version}, p3 >= ${version}\n");
-                writer.write("version=1.2.3\n");
-                writer.flush();
-            }
-
-            Logger logger = mock(Logger.class);
-            Properties prop = PropertyUtils.loadPropertyFile(circularProp, null, logger);
-            assertEquals("p1 >= 1.2.3, p2 >= 1.2.3, p3 >= 1.2.3", prop.getProperty("depends"));
-            assertEquals("1.2.3", prop.getProperty("version"));
-        } finally {
-            circularProp.delete();
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(circularProperties), StandardCharsets.UTF_8)) {
+            writer.write("depends=p1 >= ${version}, p2 >= ${version}, p3 >= ${version}\n");
+            writer.write("version=1.2.3\n");
+            writer.flush();
         }
+
+        Logger logger = mock(Logger.class);
+        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null, logger);
+        assertEquals("p1 >= 1.2.3, p2 >= 1.2.3, p3 >= 1.2.3", properties.getProperty("depends"));
+        assertEquals("1.2.3", properties.getProperty("version"));
     }
 
     public void testNonCircularReferences2Vars2Times() throws IOException {
-        File nonCircularProp = File.createTempFile("non-circular", ".properties");
+        File nonCircularProperties = File.createTempFile("non-circular", ".properties");
+        nonCircularProperties.deleteOnExit();
 
-        try {
-            try (Writer writer =
-                    new OutputStreamWriter(new FileOutputStream(nonCircularProp), StandardCharsets.UTF_8)) {
-                writer.write("test=${test2} ${test3} ${test2} ${test3}\n");
-                writer.write("test2=${test3} ${test3}\n");
-                writer.write("test3=test\n");
-                writer.flush();
-            }
-
-            Logger logger = mock(Logger.class);
-            Properties prop = PropertyUtils.loadPropertyFile(nonCircularProp, null, logger);
-            assertEquals("test test test test test test", prop.getProperty("test"));
-            assertEquals("test test", prop.getProperty("test2"));
-            assertEquals("test", prop.getProperty("test3"));
-        } finally {
-            nonCircularProp.delete();
+        try (Writer writer =
+                new OutputStreamWriter(new FileOutputStream(nonCircularProperties), StandardCharsets.UTF_8)) {
+            writer.write("test=${test2} ${test3} ${test2} ${test3}\n");
+            writer.write("test2=${test3} ${test3}\n");
+            writer.write("test3=test\n");
+            writer.flush();
         }
+
+        Logger logger = mock(Logger.class);
+        Properties properties = PropertyUtils.loadPropertyFile(nonCircularProperties, null, logger);
+        assertEquals("test test test test test test", properties.getProperty("test"));
+        assertEquals("test test", properties.getProperty("test2"));
+        assertEquals("test", properties.getProperty("test3"));
     }
 }

--- a/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
@@ -139,17 +139,18 @@ public class PropertyUtilsTest extends TestSupport {
     }
 
     public void testNonCircularReferences1Var3Times() throws IOException {
-        File circularProperties = File.createTempFile("non-circular", ".properties");
-        circularProperties.deleteOnExit();
+        File nonCircularProperties = File.createTempFile("non-circular", ".properties");
+        nonCircularProperties.deleteOnExit();
 
-        try (Writer writer = new OutputStreamWriter(new FileOutputStream(circularProperties), StandardCharsets.UTF_8)) {
+        try (Writer writer =
+                new OutputStreamWriter(new FileOutputStream(nonCircularProperties), StandardCharsets.UTF_8)) {
             writer.write("depends=p1 >= ${version}, p2 >= ${version}, p3 >= ${version}\n");
             writer.write("version=1.2.3\n");
             writer.flush();
         }
 
         Logger logger = mock(Logger.class);
-        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null, logger);
+        Properties properties = PropertyUtils.loadPropertyFile(nonCircularProperties, null, logger);
         assertEquals("p1 >= 1.2.3, p2 >= 1.2.3, p3 >= 1.2.3", properties.getProperty("depends"));
         assertEquals("1.2.3", properties.getProperty("version"));
     }

--- a/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/PropertyUtilsTest.java
@@ -26,10 +26,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
-import org.slf4j.Logger;
-
-import static org.mockito.Mockito.mock;
-
 /**
  * @author Olivier Lamy
  * @since 1.0-beta-1
@@ -48,8 +44,7 @@ public class PropertyUtilsTest extends TestSupport {
             writer.flush();
         }
 
-        Logger logger = mock(Logger.class);
-        Properties properties = PropertyUtils.loadPropertyFile(basicProperties, false, false, logger);
+        Properties properties = PropertyUtils.loadPropertyFile(basicProperties, false, false);
         assertEquals("gani_man", properties.getProperty("key"));
         assertEquals("${non_existent}", properties.getProperty("ghost"));
     }
@@ -63,8 +58,7 @@ public class PropertyUtilsTest extends TestSupport {
             writer.flush();
         }
 
-        Logger logger = mock(Logger.class);
-        Properties properties = PropertyUtils.loadPropertyFile(systemProperties, false, true, logger);
+        Properties properties = PropertyUtils.loadPropertyFile(systemProperties, false, true);
         assertEquals(properties.getProperty("key"), System.getProperty("user.dir"));
     }
 
@@ -86,8 +80,7 @@ public class PropertyUtilsTest extends TestSupport {
         Properties baseProperties = new Properties();
         baseProperties.put("pom.version", "realVersion");
 
-        Logger logger = mock(Logger.class);
-        Properties interpolated = PropertyUtils.loadPropertyFile(propertyFile, baseProperties, logger);
+        Properties interpolated = PropertyUtils.loadPropertyFile(propertyFile, baseProperties);
         assertEquals("realVersion", interpolated.get("version"));
         assertEquals("${foo}", interpolated.get("foo"));
         assertEquals("realVersion", interpolated.get("bar"));
@@ -109,8 +102,7 @@ public class PropertyUtilsTest extends TestSupport {
             writer.flush();
         }
 
-        Logger logger = mock(Logger.class);
-        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null, logger);
+        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null);
         assertEquals("${test2}", properties.getProperty("test"));
         assertEquals("${test2}", properties.getProperty("test2"));
     }
@@ -131,8 +123,7 @@ public class PropertyUtilsTest extends TestSupport {
             writer.flush();
         }
 
-        Logger logger = mock(Logger.class);
-        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null, logger);
+        Properties properties = PropertyUtils.loadPropertyFile(circularProperties, null);
         assertEquals("${test2}", properties.getProperty("test"));
         assertEquals("${test3}", properties.getProperty("test2"));
         assertEquals("${test}", properties.getProperty("test3"));
@@ -149,8 +140,7 @@ public class PropertyUtilsTest extends TestSupport {
             writer.flush();
         }
 
-        Logger logger = mock(Logger.class);
-        Properties properties = PropertyUtils.loadPropertyFile(nonCircularProperties, null, logger);
+        Properties properties = PropertyUtils.loadPropertyFile(nonCircularProperties, null);
         assertEquals("p1 >= 1.2.3, p2 >= 1.2.3, p3 >= 1.2.3", properties.getProperty("depends"));
         assertEquals("1.2.3", properties.getProperty("version"));
     }
@@ -167,8 +157,7 @@ public class PropertyUtilsTest extends TestSupport {
             writer.flush();
         }
 
-        Logger logger = mock(Logger.class);
-        Properties properties = PropertyUtils.loadPropertyFile(nonCircularProperties, null, logger);
+        Properties properties = PropertyUtils.loadPropertyFile(nonCircularProperties, null);
         assertEquals("test test test test test test", properties.getProperty("test"));
         assertEquals("test test", properties.getProperty("test2"));
         assertEquals("test", properties.getProperty("test3"));


### PR DESCRIPTION
This fixes MSHARED-1290 which was caused by https://github.com/apache/maven-shared/pull/17.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


