### PR TITLE
Issue-289: File name filtering does not work when the escapeString is the same as the file separator

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
+++ b/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
@@ -387,6 +387,7 @@ public class DefaultMavenResourcesFiltering implements MavenResourcesFiltering {
 
         if (mavenResourcesExecution.isFilterFilenames()
                 && !mavenResourcesExecution.getFilterWrappers().isEmpty()) {
+            destination = destination.replace('\\', '/');
             destination = filterFileName(destination, mavenResourcesExecution.getFilterWrappers());
         }
 

--- a/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
@@ -1042,7 +1042,9 @@ class DefaultMavenResourcesFilteringTest {
         Path failedFile = outputDirectory.resolve("subdirbar.txt");
 
         if (Files.exists(failedFile)) {
-            fail("Bug Reproduced: The Windows path separator was interpreted as an escape character, resulting in a flattened filename: " + failedFile);
+            fail(
+                    "Bug Reproduced: The Windows path separator was interpreted as an escape character, resulting in a flattened filename: "
+                            + failedFile);
         }
 
         assertTrue(Files.exists(successFile));


### PR DESCRIPTION
### Description
When `fileNameFiltering` is enabled on Windows and `escapeString` is set to `\` (the default or common Windows practice), the directory separators in the file path are read as escape characters.
Updated `DefaultMavenResourcesFiltering.getDestinationFile()` to normalize path separators to (`/`) before passing them to the filename filtering logic. This makes sure that `\` is read as a separator and not as an escape.
I have verified this locally on Windows. The new test case fails without the fix and passes with it.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
