### PR TITLE
Restore "first <resource> entry wins" for overlapping resource declarations

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
+++ b/src/main/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering.java
@@ -32,9 +32,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.apache.maven.model.Resource;
 import org.codehaus.plexus.util.DirectoryScanner;
@@ -143,6 +145,13 @@ public class DefaultMavenResourcesFiltering implements MavenResourcesFiltering {
         // Keep track of filtering being used and the properties files being filtered
         boolean isFilteringUsed = false;
         List<File> propertiesFiles = new ArrayList<>();
+
+        // Destinations already written by a previous <resource> entry in this call.
+        // Used to preserve "first <resource> entry wins" semantics for overlapping
+        // declarations — the behaviour 3.3.1 produced as a side effect of the
+        // timestamp-based overwrite gate in FilteringUtils.copyFile, lost in
+        // MSHARED-1216 / GH-333.
+        Set<Path> alreadyCopied = new HashSet<>();
 
         for (Resource resource : mavenResourcesExecution.getResources()) {
 
@@ -280,6 +289,20 @@ public class DefaultMavenResourcesFiltering implements MavenResourcesFiltering {
                 File source = new File(resourceDirectory, name);
 
                 File destinationFile = getDestinationFile(outputDirectory, targetPath, name, mavenResourcesExecution);
+
+                // Track destinations already written by a previous <resource> entry so we
+                // can preserve "first <resource> entry wins" semantics for overlapping
+                // declarations. The flatten case has its own collision policy below
+                // (warn-or-throw based on overwrite), so we deliberately do not suppress
+                // it here.
+                Path destinationPath = destinationFile.getAbsoluteFile().toPath();
+                boolean firstOccurrence = alreadyCopied.add(destinationPath);
+                if (!firstOccurrence
+                        && !mavenResourcesExecution.isFlatten()
+                        && mavenResourcesExecution.getChangeDetection() != ChangeDetection.ALWAYS) {
+                    LOGGER.debug("skipping {} — destination already written by a previous <resource> entry", name);
+                    continue;
+                }
 
                 if (mavenResourcesExecution.isFlatten() && destinationFile.exists()) {
                     if (mavenResourcesExecution.getChangeDetection() == ChangeDetection.ALWAYS) {

--- a/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringTest.java
@@ -1112,4 +1112,50 @@ class DefaultMavenResourcesFilteringTest {
         assertFalse(DefaultMavenResourcesFiltering.isPropertiesFile(new File("file.xml")));
         assertFalse(DefaultMavenResourcesFiltering.isPropertiesFile(new File("some/parent/path", "file.xml")));
     }
+
+    /**
+     * Regression guard for the maven-resources-plugin issue 471 / GH-333 scenario: when the same
+     * destination is reached by a later <resource> entry while overwrite is explicitly enabled,
+     * the later entry must still be allowed to replace the earlier one — the "first entry wins"
+     * skip introduced for the default case must not apply here.
+     */
+    @Test
+    void overlappingEntriesWithExplicitOverwriteStillReplace() throws Exception {
+        Properties projectProperties = new Properties();
+        projectProperties.put("repro.value", "REPLACED_BY_FILTERING");
+        mavenProject.setProperties(projectProperties);
+
+        String unitFilesDir = getBasedir() + "/src/test/units-files/MRP-471";
+
+        Resource filtered = new Resource();
+        filtered.setDirectory(unitFilesDir);
+        filtered.setFiltering(true);
+        filtered.addInclude("config/filtered.xml");
+
+        Resource unfiltered = new Resource();
+        unfiltered.setDirectory(unitFilesDir);
+        unfiltered.setFiltering(false);
+        unfiltered.addInclude("**");
+
+        MavenResourcesExecution execution = new MavenResourcesExecution(
+                Arrays.asList(filtered, unfiltered),
+                outputDirectory,
+                mavenProject,
+                "UTF-8",
+                Collections.emptyList(),
+                Collections.emptyList(),
+                new StubMavenSession());
+        execution.setUseDefaultFilterWrappers(true);
+        execution.setOverwrite(true);
+
+        mavenResourcesFiltering.filterResources(execution);
+
+        File filteredOut = new File(outputDirectory, "config/filtered.xml");
+        String content = new String(java.nio.file.Files.readAllBytes(filteredOut.toPath()), "UTF-8");
+        // With overwrite=true the unfiltered second pass still wins — preserve the historical
+        // 3.3.1 behaviour for callers that opt in to ChangeDetection.ALWAYS.
+        assertTrue(
+                content.contains("${repro.value}"),
+                "with overwrite=true the second <resource> entry must still clobber; got:\n" + content);
+    }
 }

--- a/src/test/java/org/apache/maven/shared/filtering/OverlappingResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/OverlappingResourcesFilteringTest.java
@@ -142,7 +142,7 @@ class OverlappingResourcesFilteringTest {
         // this guards against a fix that just turns filtering on for everything.
         assertTrue(
                 unfilteredContent.contains("${repro.value}"),
-                "static/keep-as-is.txt is matched by filtering=false and must keep the literal "
-                        + "placeholder; got:\n" + unfilteredContent);
+                "static/keep-as-is.txt is matched by filtering=false and must keep the literal " + "placeholder; got:\n"
+                        + unfilteredContent);
     }
 }

--- a/src/test/java/org/apache/maven/shared/filtering/OverlappingResourcesFilteringTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/OverlappingResourcesFilteringTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.filtering;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Resource;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getBasedir;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the regression first reported against
+ * <a href="https://github.com/apache/maven-resources-plugin/issues/471">
+ * maven-resources-plugin issue #471</a>.
+ *
+ * <p>When a single source directory is covered by two {@link Resource} entries — one with
+ * {@code filtering=true} and a narrow {@code <include>}, the other with {@code filtering=false}
+ * and a broad {@code <include>**</include>} — the file selected by the first entry must still be
+ * filtered. From {@code maven-filtering 3.3.2} onwards (pulled in by
+ * {@code maven-resources-plugin 3.4.0}), the placeholder is left as the literal {@code ${...}}
+ * text instead of being replaced.</p>
+ *
+ * <p>The {@code static/keep-as-is.txt} file, only matched by the second (unfiltered) entry, is
+ * expected to keep its placeholder verbatim — the test asserts both halves so a future fix
+ * cannot trivially "always filter everything".</p>
+ */
+@PlexusTest
+class OverlappingResourcesFilteringTest {
+
+    private final File outputDirectory = new File(getBasedir(), "target/OverlappingResourcesFilteringTest");
+    private final File baseDir = new File(getBasedir());
+    private final StubMavenProject mavenProject = new StubMavenProject(baseDir);
+
+    @Inject
+    private MavenResourcesFiltering mavenResourcesFiltering;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        if (outputDirectory.exists()) {
+            FileUtils.deleteDirectory(outputDirectory);
+        }
+        outputDirectory.mkdirs();
+
+        mavenProject.setVersion("1.0");
+        mavenProject.setGroupId("org.apache");
+        mavenProject.setName("MRP-471 repro");
+    }
+
+    @Test
+    void overlappingResourceEntriesShouldStillFilter() throws Exception {
+        Properties projectProperties = new Properties();
+        projectProperties.put("repro.value", "REPLACED_BY_FILTERING");
+        mavenProject.setProperties(projectProperties);
+
+        String unitFilesDir = getBasedir() + "/src/test/units-files/MRP-471";
+
+        // Mirrors the failing POM configuration:
+        //   <resource>
+        //     <filtering>true</filtering>
+        //     <directory>src/main/resources</directory>
+        //     <includes><include>config/filtered.xml</include></includes>
+        //   </resource>
+        //   <resource>
+        //     <filtering>false</filtering>
+        //     <directory>src/main/resources</directory>
+        //     <includes><include>**</include></includes>
+        //   </resource>
+        Resource filtered = new Resource();
+        filtered.setDirectory(unitFilesDir);
+        filtered.setFiltering(true);
+        filtered.addInclude("config/filtered.xml");
+
+        Resource unfiltered = new Resource();
+        unfiltered.setDirectory(unitFilesDir);
+        unfiltered.setFiltering(false);
+        unfiltered.addInclude("**");
+
+        List<Resource> resources = Arrays.asList(filtered, unfiltered);
+
+        MavenResourcesExecution execution = new MavenResourcesExecution(
+                resources,
+                outputDirectory,
+                mavenProject,
+                "UTF-8",
+                Collections.emptyList(),
+                Collections.emptyList(),
+                new StubMavenSession());
+        execution.setUseDefaultFilterWrappers(true);
+
+        mavenResourcesFiltering.filterResources(execution);
+
+        File filteredOut = new File(outputDirectory, "config/filtered.xml");
+        File unfilteredOut = new File(outputDirectory, "static/keep-as-is.txt");
+        assertTrue(filteredOut.isFile(), "expected " + filteredOut + " to be copied");
+        assertTrue(unfilteredOut.isFile(), "expected " + unfilteredOut + " to be copied");
+
+        String filteredContent = new String(Files.readAllBytes(filteredOut.toPath()), StandardCharsets.UTF_8);
+        String unfilteredContent = new String(Files.readAllBytes(unfilteredOut.toPath()), StandardCharsets.UTF_8);
+
+        // The placeholder targeted by the filtered <resource> entry must be replaced.
+        // Regression on maven-filtering >= 3.3.2: the literal ${repro.value} is left in place.
+        assertTrue(
+                filteredContent.contains("REPLACED_BY_FILTERING"),
+                "config/filtered.xml should have ${repro.value} replaced; got:\n" + filteredContent);
+        assertFalse(
+                filteredContent.contains("${repro.value}"),
+                "config/filtered.xml still contains the literal placeholder — see "
+                        + "https://github.com/apache/maven-resources-plugin/issues/471\n"
+                        + filteredContent);
+
+        // The second (unfiltered) entry must leave files matched only by it untouched —
+        // this guards against a fix that just turns filtering on for everything.
+        assertTrue(
+                unfilteredContent.contains("${repro.value}"),
+                "static/keep-as-is.txt is matched by filtering=false and must keep the literal "
+                        + "placeholder; got:\n" + unfilteredContent);
+    }
+}

--- a/src/test/units-files/MRP-471/config/filtered.xml
+++ b/src/test/units-files/MRP-471/config/filtered.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+  <property name="value">${repro.value}</property>
+</config>

--- a/src/test/units-files/MRP-471/static/keep-as-is.txt
+++ b/src/test/units-files/MRP-471/static/keep-as-is.txt
@@ -1,0 +1,1 @@
+Not filtered. Placeholder must stay verbatim: ${repro.value}


### PR DESCRIPTION
Fixes #333. Downstream report: apache/maven-resources-plugin#471.

## Problem

When two `<resource>` entries cover the same source directory — one with
`filtering=true` plus a narrow `<include>`, the other with `filtering=false`
plus `<include>**</include>`, the placeholder in the file selected by the
filtered entry is no longer replaced. The literal `${...}` text remains.

Bisect lands the regression on [1371dcf](https://github.com/apache/maven-filtering/commit/1371dcf66147877471c02f3bbeec8fed7b9a1910) (MSHARED-1216, "Use a caching output stream when filtering resources"). That commit removed the `boolean overwrite` parameter from
`FilteringUtils.copyFile` and the timestamp-based "don't clobber a fresher
destination" gate that came with it. Every write now goes through
`CachingOutputStream` / `CachingWriter` unconditionally if the bytes
differ, so an unfiltered second `<resource>` entry overwrites the
filtered first entry's output.

3.3.1 produced the "first entry wins" semantic as a side effect of that
gate; 3.3.2+ silently lost it. Pinning `maven-resources-plugin` to 3.3.1
is the current downstream workaround.

## Change

`DefaultMavenResourcesFiltering` now tracks destination paths already
written within a single `filterResources(...)` call and skips subsequent
writes that would land on the same path. Explicit opt-in
(`MavenResourcesExecution.setOverwrite(true)`, i.e.
`ChangeDetection.ALWAYS`) keeps the previous "second entry clobbers"
behaviour for callers that relied on it. The existing flatten-collision
policy is intentionally left untouched, a duplicate flattened name still
hits the warn-or-throw path, since that case is conceptually different.

No public API surface changes.

---

Following this checklist to help us incorporate your contribution
quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`). _N/A  - this repo defines no `run-its` profile._
