### PR TITLE
Add missing EOF checks in MultiDelimiterInterpolatorFilterReaderLineEnding.read()

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEnding.java
+++ b/src/main/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEnding.java
@@ -274,7 +274,9 @@ public class MultiDelimiterInterpolatorFilterReaderLineEnding extends AbstractFi
             beginToken = null;
             endToken = null;
 
-            key.append((char) ch);
+            if (ch >= 0) {
+                key.append((char) ch);
+            }
 
             replaceData = key.toString();
             replaceIndex = key.length();

--- a/src/main/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEnding.java
+++ b/src/main/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEnding.java
@@ -220,7 +220,7 @@ public class MultiDelimiterInterpolatorFilterReaderLineEnding extends AbstractFi
             for (int i = 0; i < getEscapeString().length(); i++) {
                 key.append((char) ch);
 
-                if (ch != getEscapeString().charAt(i) || ch == '\n' && !supportMultiLineFiltering) {
+                if (ch != getEscapeString().charAt(i) || ch == -1 || ch == '\n' && !supportMultiLineFiltering) {
                     // mismatch, EOF or EOL, no escape string here
                     in.reset();
                     inEscape = false;
@@ -243,7 +243,7 @@ public class MultiDelimiterInterpolatorFilterReaderLineEnding extends AbstractFi
             }
 
             for (int i = 0; i < begin.length(); i++) {
-                if (ch != begin.charAt(i) || ch == '\n' && !supportMultiLineFiltering) {
+                if (ch != begin.charAt(i) || ch == -1 || ch == '\n' && !supportMultiLineFiltering) {
                     // mismatch, EOF or EOL, no match
                     break;
                 }

--- a/src/test/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEndingTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/MultiDelimiterInterpolatorFilterReaderLineEndingTest.java
@@ -108,4 +108,15 @@ class MultiDelimiterInterpolatorFilterReaderLineEndingTest extends AbstractInter
 
         assertEquals("  url=\"jdbc:oracle:thin:@DB_SERVER:DB_PORT:DB_NAME\"", IOUtils.toString(reader));
     }
+
+    @Test
+    void eofAfterEscapeCharDoesNotProduceGarbage() throws Exception {
+        Reader in = new StringReader("\\");
+        MultiDelimiterInterpolatorFilterReaderLineEnding reader =
+                new MultiDelimiterInterpolatorFilterReaderLineEnding(in, interpolator, true);
+        reader.setDelimiterSpecs(Collections.singleton("@"));
+        reader.setEscapeString("\\");
+
+        assertEquals("\\", IOUtils.toString(reader));
+    }
 }


### PR DESCRIPTION
The escape-detection loop (line 223) and delimiter-detection loop (line 246)
were missing ch == -1 checks. When EOF is reached mid-token, (char) -1
produces 0xFFFF which gets appended to the key StringBuilder as garbage.
The equivalent single-delimiter class InterpolatorFilterReaderLineEnding
already has these checks.


fixes #349