### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,5 +27,6 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-build: true
+      maven4-version: '4.0.0-rc-6' # the same as used in project
       ff-goal: verify
       verify-goal: verify

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-rc-5</mavenVersion>
+    <mavenVersion>4.0.0-rc-6</mavenVersion>
 
     <hamcrestVersion>3.0</hamcrestVersion>
     <junitVersion>5.14.4</junitVersion>


### PR DESCRIPTION
4.0.0-rc-6 is released. This moves the Maven 4 version property to it and pins the same version explicitly in the Verify workflow, so CI no longer depends on the `maven4-version` default in maven-gh-actions-shared.

Verified: green on the fork before opening (`Verify` workflow, full matrix).
