### PR TITLE
Fix setEscapeString(null) to clear escape state

### DIFF
--- a/src/main/java/org/apache/maven/shared/filtering/AbstractFilterReaderLineEnding.java
+++ b/src/main/java/org/apache/maven/shared/filtering/AbstractFilterReaderLineEnding.java
@@ -65,12 +65,14 @@ public abstract class AbstractFilterReaderLineEnding extends FilterReader {
      * @param escapeString Set the value of the escape string.
      */
     public void setEscapeString(String escapeString) {
-        // TODO NPE if escapeString is null ?
         if (escapeString != null && !escapeString.isEmpty()) {
             this.escapeString = escapeString;
             this.useEscape = true;
-            calculateMarkLength();
+        } else {
+            this.escapeString = null;
+            this.useEscape = false;
         }
+        calculateMarkLength();
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/filtering/InterpolatorFilterReaderLineEndingTest.java
+++ b/src/test/java/org/apache/maven/shared/filtering/InterpolatorFilterReaderLineEndingTest.java
@@ -19,9 +19,17 @@
 package org.apache.maven.shared.filtering;
 
 import java.io.Reader;
+import java.io.StringReader;
 
 import org.codehaus.plexus.interpolation.Interpolator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
 public class InterpolatorFilterReaderLineEndingTest extends AbstractInterpolatorFilterReaderLineEndingTest {
     @Override
     protected Reader getAaaAaaReader(Reader in, Interpolator interpolator) {
@@ -47,5 +55,29 @@ public class InterpolatorFilterReaderLineEndingTest extends AbstractInterpolator
                 new InterpolatorFilterReaderLineEnding(in, interpolator, "@", "@", true);
         reader.setEscapeString(escapeString);
         return reader;
+    }
+
+    @Test
+    public void setEscapeStringNullShouldDisableEscaping() throws Exception {
+        InterpolatorFilterReaderLineEnding reader =
+                new InterpolatorFilterReaderLineEnding(new StringReader("\\${a}"), null, "${", "}", true);
+        reader.setEscapeString("\\");
+        assertEquals("\\", reader.getEscapeString());
+
+        // Now disable escaping by setting to null
+        reader.setEscapeString(null);
+        assertNull(reader.getEscapeString());
+    }
+
+    @Test
+    public void setEscapeStringEmptyShouldDisableEscaping() throws Exception {
+        InterpolatorFilterReaderLineEnding reader =
+                new InterpolatorFilterReaderLineEnding(new StringReader("\\${a}"), null, "${", "}", true);
+        reader.setEscapeString("\\");
+        assertEquals("\\", reader.getEscapeString());
+
+        // Now disable escaping by setting to empty string
+        reader.setEscapeString("");
+        assertNull(reader.getEscapeString());
     }
 }


### PR DESCRIPTION
## Problem

`setEscapeString(null)` and `setEscapeString("")` were silently ignored in `AbstractFilterReaderLineEnding`. When called after a previous non-null value, the old escape string and `useEscape` flag were retained, so escaping remained active.

## Fix

Changed `setEscapeString` to explicitly clear `escapeString` to `null` and `useEscape` to `false` when the input is null or empty, and moved `calculateMarkLength()` outside the conditional so it's always called.

## Tests

Added two tests that verify both `null` and empty string properly disable escaping:

- `setEscapeStringNullShouldDisableEscaping` -- sets escape to `\\`, then `null`, asserts `getEscapeString()` returns null
- `setEscapeStringEmptyShouldDisableEscaping` -- sets escape to `\\`, then `""`, asserts `getEscapeString()` returns null

Both tests fail before the fix (`expected: <null> but was: <\>`) and pass after. All 75 tests pass.

Closes #351
